### PR TITLE
fix: update usage of SetGradient in Classic to how it is in Wrath and Dragonflight

### DIFF
--- a/ColorPickerPlus-BCC.toc
+++ b/ColorPickerPlus-BCC.toc
@@ -5,5 +5,4 @@
 ## DefaultState: Enabled
 ## SavedVariables: ColorPickerPlusDB
 
-
 ColorPickerPlus.lua

--- a/ColorPickerPlus-Classic.toc
+++ b/ColorPickerPlus-Classic.toc
@@ -1,9 +1,8 @@
-## Interface: 11307
+## Interface: 11404
 ## Title: ColorPickerPlus
 ## Notes: Hooks into the standard Color Picker to provide text entry for colors (RGB and hex values), starting color and chosen color swatches
 ## Author: jaslm
 ## DefaultState: Enabled
 ## SavedVariables: ColorPickerPlusDB
-
 
 ColorPickerPlus.lua

--- a/ColorPickerPlus-Wrath.toc
+++ b/ColorPickerPlus-Wrath.toc
@@ -1,9 +1,8 @@
-## Interface: 30401
+## Interface: 30402
 ## Title: ColorPickerPlus
 ## Notes: Hooks into the standard Color Picker to provide text entry for colors (RGB and hex values), starting color and chosen color swatches
 ## Author: jaslm
 ## DefaultState: Enabled
 ## SavedVariables: ColorPickerPlusDB
-
 
 ColorPickerPlus.lua

--- a/ColorPickerPlus.lua
+++ b/ColorPickerPlus.lua
@@ -856,11 +856,7 @@ function MOD:CreateHueBar()
 		t:SetSize(hueBarWidth, hueTextureSize)
 		t:SetVertexColor(1.0, 1.0, 1.0, 1.0)
 		t:SetColorTexture(1.0, 1.0, 1.0, 1.0)
-        if isDragonflight or isWrath then
-            t:SetGradient("VERTICAL", CreateColor(color[i+1].r, color[i+1].g, color[i+1].b, 1), CreateColor(color[i].r, color[i].g, color[i].b, 1) )
-        else
-            t:SetGradient("VERTICAL",  color[i+1].r, color[i+1].g, color[i+1].b, color[i].r, color[i].g, color[i].b )
-        end
+        t:SetGradient("VERTICAL", CreateColor(color[i+1].r, color[i+1].g, color[i+1].b, 1), CreateColor(color[i].r, color[i].g, color[i].b, 1) )
 	end
 
 	-- Thumb indicates value position on the slider
@@ -936,12 +932,7 @@ function MOD:CreateOpacityBar()
 	t:SetSize(opacityBarWidth, opacityBarHeight)
 	t:SetVertexColor(1.0, 1.0, 1.0, 1.0)
 	t:SetColorTexture(1.0, 1.0, 1.0, 1.0)
-    
-    if isDragonflight or isWrath then
-        t:SetGradient("VERTICAL",  CreateColor(1, 1, 1, 1), CreateColor(0, 0, 0, 1) )
-    else
-        t:SetGradient("VERTICAL",  1, 1, 1, 0, 0, 0 )
-    end
+    t:SetGradient("VERTICAL",  CreateColor(1, 1, 1, 1), CreateColor(0, 0, 0, 1) )
 
  	-- Thumb indicates value position on the slider
 	local thumb = f:CreateTexture("ColorPPOpacityBarThumb") --f)

--- a/ColorPickerPlus.toc
+++ b/ColorPickerPlus.toc
@@ -1,10 +1,9 @@
-## Interface: 100100
+## Interface: 100105
 ## Title: ColorPickerPlus
 ## Notes: Hooks into the standard Color Picker to provide text entry for colors (RGB and hex values), starting color and chosen color swatches
 ## Author: jaslm
 ## IconTexture: 134563
 ## DefaultState: Enabled
 ## SavedVariables: ColorPickerPlusDB
-
 
 ColorPickerPlus.lua


### PR DESCRIPTION
SetGradient now expects TextureBase:SetGradient(orientation, minColor, maxColor) in Classic 1.14.4 as it is in Wrath and Dragonflight.