### PR TITLE
Fixing preview pane alpha when using Gradient or Hue selection

### DIFF
--- a/ColorPickerPlus.lua
+++ b/ColorPickerPlus.lua
@@ -724,10 +724,18 @@ local function GradientOnMouseDown(self, button)
 	if self:IsMouseOver() and IsMouseButtonDown(LeftButton) then
 		if not (lockedHueBar or lockedOpacityBar) then
 			lockedGradient = true
-			if ColorPickerFrame.hasOpacity then
-				lockedOpacity = 1 - (ColorPickerFrame.GetColorAlpha and ColorPickerFrame:GetColorAlpha() or opacitySliderFrame:GetValue())
+			if isDragonflight then
+				if ColorPickerFrame.hasOpacity then
+					lockedOpacity = (ColorPickerFrame.GetColorAlpha and ColorPickerFrame:GetColorAlpha() or opacitySliderFrame:GetValue())
+				else
+					lockedOpacity = 0
+				end
 			else
-				lockedOpacity = 1
+				if ColorPickerFrame.hasOpacity then
+					lockedOpacity = 1 - (ColorPickerFrame.GetColorAlpha and ColorPickerFrame:GetColorAlpha() or opacitySliderFrame:GetValue())
+				else
+					lockedOpacity = 1
+				end
 			end
 		end
 	end
@@ -842,10 +850,18 @@ local function HueBarOnMouseDown(self, button)
 	if self:IsMouseOver() and IsMouseButtonDown(LeftButton) then
 		if not (lockedGradient or lockedOpacityBar) then
 			lockedHueBar = true
-			if ColorPickerFrame.hasOpacity then
-				lockedOpacity = 1 - (ColorPickerFrame.GetColorAlpha and ColorPickerFrame:GetColorAlpha() or opacitySliderFrame:GetValue())
+			if isDragonflight then
+				if ColorPickerFrame.hasOpacity then
+					lockedOpacity = (ColorPickerFrame.GetColorAlpha and ColorPickerFrame:GetColorAlpha() or opacitySliderFrame:GetValue())
+				else
+					lockedOpacity = 0
+				end
 			else
-				lockedOpacity = 1
+				if ColorPickerFrame.hasOpacity then
+					lockedOpacity = 1 - (ColorPickerFrame.GetColorAlpha and ColorPickerFrame:GetColorAlpha() or opacitySliderFrame:GetValue())
+				else
+					lockedOpacity = 1
+				end
 			end
 			MOD:UpdateHueBarThumb()
 		end


### PR DESCRIPTION
When clicking on the HueBar or the Gradient field, the alpha value would be inverted:
![image](https://github.com/Jaslm/ColorPickerPlus/assets/10164755/359feede-8a95-46ef-9101-322801cd17d9)

`GradientOnMouseDown` and `HueBarOnMouseDown` were not respecting the recent changes in Dragonflight which removed the alpha-value reversion.