### PR TITLE
Classic and cata fixes

### DIFF
--- a/ColorPickerPlus.lua
+++ b/ColorPickerPlus.lua
@@ -1424,7 +1424,7 @@ function MOD:UpdateAlphaText()
 	if isDragonflight then
 		a = ColorPickerFrame:GetColorAlpha() * 100
 	else
-		a = 1 - opacitySliderFrame:GetValue() * 100 -- still keeping value OpacityFrame, to coordinate with WoW settings
+		a = (1 - opacitySliderFrame:GetValue()) * 100 -- still keeping value OpacityFrame, to coordinate with WoW settings
 	end
 	a = math.floor(a + 0.05)
 	ColorPPBoxA:SetText(string.format("%d", a))

--- a/ColorPickerPlus.lua
+++ b/ColorPickerPlus.lua
@@ -48,9 +48,8 @@ local colorSwatchHeight = 120
 local isClassic = (WOW_PROJECT_ID == WOW_PROJECT_CLASSIC)
 local isCata = (WOW_PROJECT_ID == WOW_PROJECT_CATACLYSM_CLASSIC)
 local isDragonflight = floor(select(4, GetBuildInfo()) / 10000) == 10
-local isModern = isCata or isDragonflight
 
-local opacitySliderFrame = OpacityFrameSlider and OpacityFrameSlider or OpacitySliderFrame
+local opacitySliderFrame = OpacitySliderFrame and OpacitySliderFrame or OpacityFrameSlider
 
 -- bgTable used in creation of backdrops
 local bgTable = {
@@ -207,12 +206,30 @@ local function HSV_to_RGB(ch, cs, cv)
 	return r, g, b
 end
 
+function MOD:SetColor(r, g, b)
+	if isDragonflight then
+		ColorPickerFrame.Content.ColorPicker:SetColorRGB(r, g, b)
+	else
+		ColorPickerFrame:SetColorRGB(r, g, b)
+	end
+	ColorPickerFrame.swatchFunc()
+	MOD:UpdateHSVfromColorPickerRGB()
+end
+
+function MOD:SetAlpha(a)
+	if isDragonflight then
+		ColorPickerFrame.Content.ColorPicker:SetColorAlpha(a)
+	else
+		opacitySliderFrame:SetValue(1 - a)
+	end
+end
+
 function MOD:UpdateHSVfromColorPickerRGB()
 	colorHue, colorSat, colorVal = RGB_to_HSV(ColorPickerFrame:GetColorRGB())
 end
 
 function MOD:SetRGBfromHSV()
-	if isModern then
+	if isDragonflight then
 		ColorPickerFrame.Content.ColorPicker:SetColorRGB(HSV_to_RGB(colorHue, colorSat, colorVal))
 	else
 		ColorPickerFrame:SetColorRGB(HSV_to_RGB(colorHue, colorSat, colorVal))
@@ -222,7 +239,7 @@ end
 function MOD:GetAlpha()
 	local colorAlpha
 	if ColorPickerFrame.hasOpacity then
-		if isModern then
+		if isDragonflight then
 			colorAlpha = ColorPickerFrame:GetColorAlpha()
 		else
 			colorAlpha = 1 - opacitySliderFrame:GetValue()
@@ -289,7 +306,7 @@ end
 
 function MOD:UpdateOpacityBarThumb()
 	local a
-	if isModern then
+	if isDragonflight then
 		a = ColorPickerFrame:GetColorAlpha()
 	else
 		a = opacitySliderFrame:GetValue()
@@ -349,7 +366,8 @@ end
 
 function MOD:CleanUpColorPickerFrame()
 	-- First, disable some standard Blizzard components
-	if isModern then
+
+	if isDragonflight then
 		ColorPickerFrame:Hide()
 		ColorPickerFrame.Content:Hide()
 		ColorPickerFrame.Content.ColorPicker:Hide()
@@ -377,7 +395,7 @@ function MOD:CleanUpColorPickerFrame()
 	end
 
 	-- Add the "Color Picker Plus" dialog title
-	if isClassic then
+	if isClassic or isCata then
 		local t = ColorPickerFrame:CreateFontString(nil, "ARTWORK", "GameFontNormal")
 		t:SetFontObject("GameFontNormal")
 		t:SetText("Color Picker Plus")
@@ -433,18 +451,8 @@ local function OldColorOnMouseUp(frame, button)
 		local r, g, b, a = frame:GetBackdropColor()
 
 		-- update color and opacity variables
-		if isModern then
-			ColorPickerFrame.Content.ColorPicker:SetColorRGB(r, g, b)
-			ColorPickerFrame.swatchFunc()
-			MOD:UpdateHSVfromColorPickerRGB()
-			ColorPickerFrame.Content.ColorPicker:SetColorAlpha(a)
-		else
-			ColorPickerFrame:SetColorRGB(r, g, b)
-			ColorPickerFrame.func()
-			MOD:UpdateHSVfromColorPickerRGB()
-			opacitySliderFrame:SetValue(1 - a)
-		end
-
+		MOD:SetColor(r, g, b)
+		MOD:SetAlpha(a)
 		MOD:UpdateColorGraphics()
 		MOD:UpdateColorTexts()
 		MOD:UpdateAlphaText()
@@ -555,18 +563,8 @@ function MOD:CreateCopyPasteArea()
 		local r, g, b, a = ColorPPCopiedColor:GetBackdropColor()
 
 		-- update color and opacity variables
-		if isModern then
-			ColorPickerFrame.Content.ColorPicker:SetColorRGB(r, g, b)
-			ColorPickerFrame.swatchFunc()
-			MOD:UpdateHSVfromColorPickerRGB()
-			ColorPickerFrame.Content.ColorPicker:SetColorAlpha(a)
-		else
-			ColorPickerFrame:SetColorRGB(r, g, b)
-			ColorPickerFrame.func()
-			MOD:UpdateHSVfromColorPickerRGB()
-			opacitySliderFrame:SetValue(1 - a)
-		end
-
+		MOD:SetColor(r, g, b)
+		MOD:SetAlpha(a)
 		MOD:UpdateColorGraphics()
 		MOD:UpdateColorTexts()
 		MOD:UpdateAlphaText()
@@ -590,18 +588,8 @@ local function PaletteSwatchOnMouseUp(frame, button)
 			else -- Set the chosen color to the swatch color
 				r, g, b, a = frame:GetBackdropColor()
 
-				if isModern then
-					ColorPickerFrame.Content.ColorPicker:SetColorRGB(r, g, b)
-					ColorPickerFrame.swatchFunc()
-					MOD:UpdateHSVfromColorPickerRGB()
-					ColorPickerFrame.Content.ColorPicker:SetColorAlpha(a)
-				else
-					ColorPickerFrame:SetColorRGB(r, g, b)
-					ColorPickerFrame.func()
-					MOD:UpdateHSVfromColorPickerRGB()
-					opacitySliderFrame:SetValue(1 - a)
-				end
-
+				MOD:SetColor(r, g, b)
+				MOD:SetAlpha(a)
 				MOD:UpdateColorGraphics()
 				MOD:UpdateColorTexts()
 				MOD:UpdateAlphaText()
@@ -654,18 +642,8 @@ local function ClassPaletteSwatchOnMouseUp(frame, button)
 		-- Set the chosen color to the swatch color
 		r, g, b, a = frame:GetBackdropColor()
 
-		if isModern then
-			ColorPickerFrame.Content.ColorPicker:SetColorRGB(r, g, b)
-			ColorPickerFrame.swatchFunc()
-			MOD:UpdateHSVfromColorPickerRGB()
-			ColorPickerFrame.Content.ColorPicker:SetColorAlpha(a)
-		else
-			ColorPickerFrame:SetColorRGB(r, g, b)
-			ColorPickerFrame.func()
-			MOD:UpdateHSVfromColorPickerRGB()
-			opacitySliderFrame:SetValue(1 - a)
-		end
-
+		MOD:SetColor(r, g, b)
+		MOD:SetAlpha(a)
 		MOD:UpdateColorGraphics()
 		MOD:UpdateColorTexts()
 		MOD:UpdateAlphaText()
@@ -673,7 +651,7 @@ local function ClassPaletteSwatchOnMouseUp(frame, button)
 end
 
 function MOD:CreateClassPalette()
-	local rows = isModern and 4 or 3
+	local rows = isDragonflight and 4 or 3
 	local cols = 4
 	local spacer = 2
 	local margin = 0
@@ -724,7 +702,7 @@ local function GradientOnMouseDown(self, button)
 		if not (lockedHueBar or lockedOpacityBar) then
 			lockedGradient = true
 			if ColorPickerFrame.hasOpacity then
-				if isModern then
+				if isDragonflight then
 					lockedOpacity = ColorPickerFrame:GetColorAlpha()
 				else
 					lockedOpacity = 1 - opacitySliderFrame:GetValue()
@@ -786,14 +764,7 @@ local function GradientOnUpdate(self)
 
 			local r, g, b = HSV_to_RGB(colorHue, colorSat, colorVal)
 
-			if isModern then
-				ColorPickerFrame.Content.ColorPicker:SetColorRGB(r, g, b)
-				ColorPickerFrame.swatchFunc()
-			else
-				ColorPickerFrame:SetColorRGB(r, g, b)
-				ColorPickerFrame.func()
-			end
-
+			MOD:SetColor(r, g, b)
 			ColorPPChosenColor:SetBackdropColor(r, g, b, lockedOpacity)
 			MOD:UpdateColorTexts()
 			MOD:UpdateGradientThumb()
@@ -842,7 +813,7 @@ local function HueBarOnMouseDown(self, button)
 		if not (lockedGradient or lockedOpacityBar) then
 			lockedHueBar = true
 			if ColorPickerFrame.hasOpacity then
-				if isModern then
+				if isDragonflight then
 					lockedOpacity = ColorPickerFrame:GetColorAlpha()
 				else
 					lockedOpacity = 1 - opacitySliderFrame:GetValue()
@@ -887,13 +858,7 @@ local function HueBarOnUpdate(self) -- it's actually the holder that receives th
 			end
 
 			local r, g, b = HSV_to_RGB(colorHue, colorSat, colorVal)
-			if isModern then
-				ColorPickerFrame.Content.ColorPicker:SetColorRGB(r, g, b)
-				ColorPickerFrame.swatchFunc()
-			else
-				ColorPickerFrame:SetColorRGB(r, g, b)
-				ColorPickerFrame.func()
-			end
+			MOD:SetColor(r, g, b)
 			MOD:UpdateColorTexts()
 			ColorPPChosenColor:SetBackdropColor(r, g, b, lockedOpacity)
 			ColorPPColorOverlay:SetVertexColor(HSV_to_RGB(colorHue, 1, 1))
@@ -985,7 +950,7 @@ local function OpacityBarOnUpdate(self)
 				a = 1 - ((top - y) / height)
 			end
 
-			if isModern then
+			if isDragonflight then
 				ColorPickerFrame.Content.ColorPicker:SetColorAlpha(a)
 				MOD:UpdateAlphaText()
 				local r, g, b = ColorPickerFrame:GetColorRGB()
@@ -1240,7 +1205,7 @@ function MOD:Initialize_UI()
 	MOD:CreateColorSwatches()
 	MOD:CreateHelpFrame()
 	MOD:CreatePaletteSwitcher()
-	if isModern then
+	if isDragonflight then
 		ColorPickerFrame.Footer.CancelButton:SetSize(100, 22)
 		ColorPickerFrame.Footer.OkayButton:SetSize(100, 22)
 	end
@@ -1297,14 +1262,7 @@ function MOD:RGBTextChanged(textBox, userInput)
 		return
 	end
 
-	if isModern then
-		ColorPickerFrame.Content.ColorPicker:SetColorRGB(r, g, b)
-		ColorPickerFrame.swatchFunc()
-	else
-		ColorPickerFrame:SetColorRGB(r, g, b)
-		ColorPickerFrame.func()
-	end
-
+	MOD:SetColor(r, g, b)
 	MOD:UpdateHSVfromColorPickerRGB()
 	MOD:UpdateColorGraphics()
 	MOD:UpdateHSVTexts()
@@ -1341,14 +1299,7 @@ function MOD:HexTextChanged(textBox, userInput)
 		return
 	end
 
-	if isModern then
-		ColorPickerFrame.Content.ColorPicker:SetColorRGB(r, g, b)
-		ColorPickerFrame.swatchFunc()
-	else
-		ColorPickerFrame:SetColorRGB(r, g, b)
-		ColorPickerFrame.func()
-	end
-
+	MOD:SetColor(r, g, b)
 	MOD:UpdateHSVfromColorPickerRGB()
 	MOD:UpdateColorGraphics()
 	MOD:UpdateHSVTexts()
@@ -1400,14 +1351,7 @@ function MOD:HSVTextChanged(textBox, userInput)
 	colorHue, colorSat, colorVal = h, s, v
 	local r, g, b = HSV_to_RGB(h, s, v)
 
-	if isModern then
-		ColorPickerFrame.Content.ColorPicker:SetColorRGB(r, g, b)
-		ColorPickerFrame.swatchFunc()
-	else
-		ColorPickerFrame:SetColorRGB(r, g, b)
-		ColorPickerFrame.func()
-	end
-
+	MOD:SetColor(r, g, b)
 	MOD:UpdateColorGraphics()
 	MOD:UpdateRGBTexts()
 	MOD:UpdateHexText()
@@ -1470,21 +1414,14 @@ function MOD:AlphaTextChanged(textBox, userInput)
 	end
 	a = a / 100
 
-	if isModern then
-		ColorPickerFrame.Content.ColorPicker:SetColorAlpha(a)
-		ColorPickerFrame.swatchFunc()
-	else
-		opacitySliderFrame:SetValue(1 - a)
-		ColorPickerFrame.func()
-	end
-
+	MOD:SetAlpha(a)
 	MOD:UpdateOpacityBarThumb()
 	MOD:UpdateChosenColor()
 end
 
 function MOD:UpdateAlphaText()
 	local a
-	if isModern then
+	if isDragonflight then
 		a = ColorPickerFrame:GetColorAlpha() * 100
 	else
 		a = 1 - opacitySliderFrame:GetValue() * 100 -- still keeping value OpacityFrame, to coordinate with WoW settings


### PR DESCRIPTION
810cfb965d9196ac9194a5ed96b01d01e2fe0814 doesn't seem to be effective in fixing the cata errors. The cata color picker frame does not seem to have been changed to match retail as that commit would suggest.

For some reason, both OpacityFrameSlider and OpacitySliderFrame exist on classic and cata, but OpacityFrameSlider is the correct one to use, so the order of preference is reversed.

This also fixes an order of operations issue causing the text displaying the selected alpha value to be incorrect.

